### PR TITLE
Add reload checkbox

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,7 +85,7 @@ module.exports = {
                 "before": true
             }
         ],
-        "line-comment-position": "error",
+        "line-comment-position": "off",
         "linebreak-style": [
             "error",
             "unix"
@@ -144,7 +144,7 @@ module.exports = {
         "no-implicit-coercion": "error",
         "no-implicit-globals": "error",
         "no-implied-eval": "error",
-        "no-inline-comments": "error",
+        "no-inline-comments": "off",
         "no-invalid-this": "error",
         "no-iterator": "error",
         "no-label-var": "error",

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ I finally realized that a simple solution might be just what I needed and I crea
 With this script, if you have 80 notifications for three different Revisions, you’ll only see 3 links instead of 80. The script does this only when you toggle the grouping via a “Group Notifications” button added the page, and it remembers your choice for the next time you load it.
 
 ![Image of Notifications Grouped by Revision](images/phabricator-notifications-grouped-blur.png)
+
+The script also adds a checkbox that will allow reloading of the page when a new notification appears (assuming you have push notifications enabled in Phabricator) or when clicking on a notification. This will help keep the list up-to-date.

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -173,18 +173,19 @@
     }
 
     function addReloadCheckbox() {
+        const area = document.createElement('div');
+        area.className = 'reload-checkbox-area';
         const button = document.createElement('input');
-        button.className = '';
         button.id = 'reload-checkbox';
         button.type = 'checkbox';
         const buttonTitle = document.createElement('label');
-        buttonTitle.className = '';
         buttonTitle.for = 'reload-checkbox';
         buttonTitle.innerText = 'Reload on Update';
         const buttonArea = document.querySelector('.phui-header-action-links');
+        area.appendChild(buttonTitle);
+        area.appendChild(button);
         if (buttonArea) {
-            buttonArea.appendChild(buttonTitle);
-            buttonArea.appendChild(button);
+            buttonArea.appendChild(area);
         }
         return button;
     }
@@ -211,7 +212,26 @@
         links.forEach(link => link.addEventListener('click', callback));
     }
 
+    function addStyles() {
+        const styles = `
+.reload-checkbox-area {
+    display: inline-flex;
+    height: 2em;
+    margin: 4px;
+    align-items: center;
+}
+
+.reload-checkbox-area label {
+    padding: 0.2em;
+}
+        `;
+        const styleTag = document.createElement('style');
+        styleTag.innerText = styles;
+        document.body.appendChild(styleTag);
+    }
+
     // ------- Main Program -------
+    addStyles();
     let notes = Array.from(document.querySelectorAll('.phabricator-notification')).map(createNoteFromNotificationNode);
     const button = addCollapseToggleButton();
     button.addEventListener('click', () => {

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -206,6 +206,11 @@
         observer.observe(count, config);
     }
 
+    function watchNoteClicks(callback) {
+        const links = document.querySelectorAll('.phabricator-notification-unread');
+        links.forEach(link => link.addEventListener('click', callback));
+    }
+
     // ------- Main Program -------
     let notes = Array.from(document.querySelectorAll('.phabricator-notification')).map(createNoteFromNotificationNode);
     const button = addCollapseToggleButton();
@@ -231,5 +236,9 @@
             waitThenReload();
         }
     });
-
+    watchNoteClicks(() => {
+        if (getReloadState()) {
+            waitThenReload();
+        }
+    });
 })();

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Phabricator Notification Grouping
 // @namespace    https://github.com/sirbrillig/phabricator-grouping
-// @version      1.0.2
+// @version      1.1.0
 // @description  Allows collapsing Phabricator notifications to one-per-revision
 // @author       Payton Swick <payton@foolord.com>
 // @match        https://code.a8c.com/notification/*

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -189,6 +189,23 @@
         return button;
     }
 
+    function waitThenReload() {
+        setTimeout(() => window.location.reload(), 1000);
+    }
+
+    function watchAlertCount(callback) {
+        const count = document.querySelector('.phabricator-main-menu-alert-count');
+        if (! count) {
+            return;
+        }
+        const config = {
+            attributes: true,
+            childList: true,
+        };
+        const observer = new MutationObserver(callback);
+        observer.observe(count, config);
+    }
+
     // ------- Main Program -------
     let notes = Array.from(document.querySelectorAll('.phabricator-notification')).map(createNoteFromNotificationNode);
     const button = addCollapseToggleButton();
@@ -209,4 +226,10 @@
     if (getReloadState()) {
         toggleReloadBox(reloadCheckbox, getReloadState());
     }
+    watchAlertCount(() => {
+        if (getReloadState()) {
+            waitThenReload();
+        }
+    });
+
 })();


### PR DESCRIPTION
With this PR, the script also adds a checkbox that will allow reloading of the page when a new notification appears (assuming you have push notifications enabled in Phabricator) or when clicking on a notification. This will help keep the list up-to-date.

![Screen Shot 2019-06-26 at 10 26 43 AM](https://user-images.githubusercontent.com/2036909/60188205-ea4d5480-97fc-11e9-8907-b91d8a867449.png)
