### PR TITLE
Show collapsed notification count

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,6 +124,7 @@ module.exports = {
         "no-catch-shadow": "error",
         "no-confusing-arrow": "error",
         "no-continue": "error",
+        "no-console": "off",
         "no-div-regex": "error",
         "no-duplicate-imports": "error",
         "no-else-return": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,7 +96,7 @@ module.exports = {
         "max-classes-per-file": "error",
         "max-depth": "error",
         "max-len": "off",
-        "max-lines": "error",
+        "max-lines": "off",
         "max-lines-per-function": "error",
         "max-nested-callbacks": "error",
         "max-params": "error",

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Phabricator Notification Grouping
 // @namespace    https://github.com/sirbrillig/phabricator-grouping
-// @version      1.1.0
+// @version      1.2.0
 // @description  Allows collapsing Phabricator notifications to one-per-revision
 // @author       Payton Swick <payton@foolord.com>
 // @match        https://code.a8c.com/notification/*

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -270,7 +270,7 @@
 
     // ------- Main Program -------
     addStyles();
-    let notes = Array.from(document.querySelectorAll('.phabricator-notification')).map(createNoteFromNotificationNode);
+    let notes = Array.from(document.querySelectorAll('.phabricator-notification:not(.no-notifications)')).map(createNoteFromNotificationNode);
     const button = addCollapseToggleButton();
     button.addEventListener('click', () => {
         setCollapsedState(! getCollapsedState());

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -223,7 +223,8 @@
 
     function watchNoteClicks(callback) {
         const links = document.querySelectorAll('.phabricator-notification-unread');
-        links.forEach(link => link.addEventListener('click', callback));
+        const handleClick = event => event.metaKey && callback();
+        links.forEach(link => link.addEventListener('click', handleClick));
     }
 
     function toggleCollapsedAlertCount(collapsedNoteCount, isCollapsed) {
@@ -275,11 +276,13 @@
     button.addEventListener('click', () => {
         setCollapsedState(! getCollapsedState());
         notes = toggleCollapsedNotes(notes, getCollapsedState());
+        console.log('Current status of notes', notes);
         toggleCollapsedButton(button, getCollapsedState());
         toggleCollapsedAlertCount(notes.filter(note => ! note.collapsed).length, getCollapsedState());
     });
     if (getCollapsedState()) {
         notes = toggleCollapsedNotes(notes, getCollapsedState());
+        console.log('Current status of notes', notes);
         toggleCollapsedButton(button, getCollapsedState());
         toggleCollapsedAlertCount(notes.filter(note => ! note.collapsed).length, getCollapsedState());
     }

--- a/phabricator-grouping.user.js
+++ b/phabricator-grouping.user.js
@@ -226,6 +226,22 @@
         links.forEach(link => link.addEventListener('click', callback));
     }
 
+    function toggleCollapsedAlertCount(collapsedNoteCount, isCollapsed) {
+        let countElement = document.querySelector('.phabricator-notification-grouping-grouped-alert-count');
+        const countElementExists = Boolean(countElement);
+        if (! countElementExists) {
+            countElement = document.createElement('span');
+            const container = document.querySelector('.phui-profile-header .phui-header-header');
+            if (! container) {
+                console.error('Cannot find container for collapsed alert count');
+                return;
+            }
+            container.appendChild(countElement);
+        }
+        countElement.innerText = `(${collapsedNoteCount})`;
+        countElement.className = isCollapsed ? 'phabricator-notification-grouping-grouped-alert-count' : 'phabricator-notification-grouping-grouped-alert-count--hidden';
+    }
+
     function addStyles() {
         const styles = `
 .reload-checkbox-area {
@@ -237,6 +253,14 @@
 
 .reload-checkbox-area label {
     padding: 0.2em;
+}
+
+.phabricator-notification-grouping-grouped-alert-count {
+    padding: 0.3em;
+}
+
+.phabricator-notification-grouping-grouped-alert-count--hidden {
+    display: none;
 }
         `;
         const styleTag = document.createElement('style');
@@ -252,10 +276,12 @@
         setCollapsedState(! getCollapsedState());
         notes = toggleCollapsedNotes(notes, getCollapsedState());
         toggleCollapsedButton(button, getCollapsedState());
+        toggleCollapsedAlertCount(notes.filter(note => ! note.collapsed).length, getCollapsedState());
     });
     if (getCollapsedState()) {
         notes = toggleCollapsedNotes(notes, getCollapsedState());
         toggleCollapsedButton(button, getCollapsedState());
+        toggleCollapsedAlertCount(notes.filter(note => ! note.collapsed).length, getCollapsedState());
     }
 
     const reloadCheckbox = addReloadCheckbox();


### PR DESCRIPTION
This shows a count of the collapsed notifications next to the "New notifications" header when there are collapsed notifications.

![Screen Shot 2019-07-18 at 7 42 23 PM](https://user-images.githubusercontent.com/2036909/61499145-2efb8400-a994-11e9-9225-2dc6a87011a2.png)


It also fixes a bug which caused unnecessary reloads. The alert count element actually changes just by clicking on it, which triggers an unnecessary reload and makes it impossible to examine the notifications menu. This change actually looks for changes in the count number itself.
